### PR TITLE
feat: 바텀시트 틀 및 드래그 기능 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="bottom-sheet"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/common/bottom-sheet/BottomSheet.tsx
+++ b/src/components/common/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,32 @@
+import { ReactNode, forwardRef } from 'react';
+import BottomSheetPortal from './BottomSheetPortal';
+
+interface Props {
+  children: ReactNode;
+  title?: string;
+}
+
+const BottomSheet = forwardRef<HTMLDivElement, Props>(
+  ({ children, title }, ref) => {
+    return (
+      <BottomSheetPortal>
+        <div className='fixed bottom-0 left-0 right-0 top-0 z-[100] hidden bg-black/50'>
+          <div
+            ref={ref}
+            role='dialog'
+            className='fixed -bottom-60 left-0 right-0 mx-auto hidden max-h-[90dvh] min-h-100 w-full max-w-500 -translate-x-1/2 flex-col rounded-t-[20px] bg-white px-32 pb-60 transition-transform duration-0 ease-out'
+          >
+            <div className='mx-auto my-8 h-4 w-[70px] shrink-0 rounded-full bg-grey-6' />
+            <div className='py-12'>
+              {title && <h2 className='text-22 w-full font-700'>{title}</h2>}
+            </div>
+            {children}
+          </div>
+        </div>
+      </BottomSheetPortal>
+    );
+  },
+);
+BottomSheet.displayName = 'BottomSheet';
+
+export default BottomSheet;

--- a/src/components/common/bottom-sheet/BottomSheetPortal.tsx
+++ b/src/components/common/bottom-sheet/BottomSheetPortal.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+interface Props {
+  children: ReactNode;
+}
+
+const BottomSheetPortal = ({ children }: Props) => {
+  const [mountedPortal, setMountedPortal] = useState<Element | null>(null);
+
+  useEffect(() => {
+    setMountedPortal(document.querySelector('#bottom-sheet'));
+  }, []);
+
+  if (!mountedPortal) return;
+  return ReactDOM.createPortal(children, mountedPortal);
+};
+
+export default BottomSheetPortal;

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -1,0 +1,199 @@
+import { MutableRefObject, useCallback, useRef } from 'react';
+
+interface Metrics {
+  initTouchPosition: number | null;
+  initTransformValue: number;
+  isContentAreaTouched: boolean;
+  closingY: number;
+}
+
+const TRANSFORM_DURATION = '200ms';
+
+const useBottomSheet = () => {
+  const bottomSheetRef = useCallback((bottomSheetElement: HTMLDivElement) => {
+    if (!bottomSheetElement || !bottomSheetElement?.parentElement) {
+      return;
+    }
+    bottomSheet.current = bottomSheetElement;
+    backdrop.current = bottomSheetElement.parentElement;
+
+    bottomSheetElement.parentElement.addEventListener(
+      'mouseup',
+      closeBottomSheet,
+    );
+    bottomSheetElement.parentElement.addEventListener(
+      'touchend',
+      closeBottomSheet,
+    );
+    bottomSheetElement.addEventListener('mouseup', (e) => e.stopPropagation());
+    bottomSheetElement.addEventListener('touchend', (e) => e.stopPropagation());
+
+    bottomSheetElement.addEventListener('touchstart', handleTouch.start);
+    bottomSheetElement.addEventListener('touchmove', handleTouch.move);
+    bottomSheetElement.addEventListener('touchend', handleTouch.end);
+
+    bottomSheetElement.addEventListener('mousedown', handleMouse.down);
+    bottomSheetElement.addEventListener('mousemove', handleMouse.move);
+    bottomSheetElement.addEventListener('mouseup', handleMouse.up);
+    bottomSheetElement.addEventListener('mouseleave', handleMouse.leave);
+
+    contentRef.current?.addEventListener('touchstart', handleContentTouch);
+    contentRef.current?.addEventListener('mousedown', handleContentTouch);
+
+    return () => {
+      bottomSheetElement.parentElement?.removeEventListener(
+        'mouseup',
+        closeBottomSheet,
+      );
+      bottomSheetElement.parentElement?.removeEventListener(
+        'touchend',
+        closeBottomSheet,
+      );
+      bottomSheetElement.removeEventListener('mouseup', (e) =>
+        e.stopPropagation(),
+      );
+      bottomSheetElement.removeEventListener('touchend', (e) =>
+        e.stopPropagation(),
+      );
+
+      bottomSheetElement.removeEventListener('touchstart', handleTouch.start);
+      bottomSheetElement.removeEventListener('touchmove', handleTouch.move);
+      bottomSheetElement.removeEventListener('touchend', handleTouch.end);
+
+      bottomSheetElement.removeEventListener('mousedown', handleMouse.down);
+      bottomSheetElement.removeEventListener('mousemove', handleMouse.move);
+      bottomSheetElement.removeEventListener('mouseup', handleMouse.up);
+      bottomSheetElement.removeEventListener('mouseleave', handleMouse.leave);
+
+      contentRef.current?.removeEventListener('touchstart', handleContentTouch);
+      contentRef.current?.removeEventListener('mousedown', handleContentTouch);
+    };
+  }, []);
+
+  const bottomSheet: MutableRefObject<HTMLDivElement | null> = useRef(null);
+  const backdrop: MutableRefObject<HTMLElement | null> = useRef(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const metrics = useRef<Metrics>({
+    initTouchPosition: null,
+    initTransformValue: 0,
+    isContentAreaTouched: false,
+    closingY: 0,
+  });
+
+  // 바텀시트 열고 닫기
+  const openBottomSheet = () => {
+    const bottomSheetElement = bottomSheet.current;
+    const backdropElement = backdrop.current;
+    if (!bottomSheetElement || !backdropElement) {
+      return;
+    }
+    bottomSheetElement.style.transitionDuration = '0ms';
+    bottomSheetElement.style.display = 'flex';
+    backdropElement.style.display = 'flex';
+
+    const bottomSheetHeight = bottomSheetElement.clientHeight;
+    bottomSheetElement.style.transform = `translateY(${bottomSheetHeight}px)`;
+    metrics.current.closingY = bottomSheetHeight / 2;
+
+    setTimeout(() => {
+      bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+      bottomSheetElement.style.transform = `translateY(0px)`;
+    }, 10);
+  };
+
+  const closeBottomSheet = () => {
+    const bottomSheetElement = bottomSheet.current;
+    const backdropElement = backdrop.current;
+    if (!bottomSheetElement || !backdropElement) {
+      return;
+    }
+    const bottomSheetHeight = bottomSheetElement.clientHeight;
+    bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+    bottomSheetElement.style.transform = `translateY(${bottomSheetHeight}px)`;
+
+    setTimeout(() => {
+      bottomSheetElement.style.display = 'none';
+      backdropElement.style.display = 'none';
+    }, 150);
+  };
+
+  // 바텀시트 드래그
+  const handleStart = (clientY: number) => {
+    const bottomSheetElement = bottomSheet.current;
+    if (!bottomSheetElement) {
+      return;
+    }
+    bottomSheetElement.style.transitionDuration = '0ms';
+
+    const initTransformValue = Number(
+      bottomSheetElement.style.transform
+        .replace('translateY(', '')
+        .replace('px)', '') || 0,
+    );
+    metrics.current.initTransformValue = initTransformValue;
+    metrics.current.initTouchPosition = clientY;
+  };
+
+  const handleMove = (clientY: number, e: Event) => {
+    const bottomSheetElement = bottomSheet.current;
+    const { initTouchPosition, initTransformValue, isContentAreaTouched } =
+      metrics.current;
+    if (!initTouchPosition || !bottomSheetElement || isContentAreaTouched) {
+      return;
+    }
+    e.preventDefault();
+
+    const currTouchPosition = clientY;
+    let diff =
+      (initTouchPosition - currTouchPosition) * -1 + initTransformValue;
+    if (diff < 0) {
+      diff = Math.floor(diff / 10);
+    }
+    bottomSheetElement.style.transform = `translateY(${diff}px)`;
+  };
+
+  const handleEnd = () => {
+    const bottomSheetElement = bottomSheet.current;
+    const { initTouchPosition, closingY } = metrics.current;
+    if (!initTouchPosition || !bottomSheetElement) {
+      return;
+    }
+
+    const finalTransformValue = Number(
+      bottomSheetElement.style.transform
+        .replace('translateY(', '')
+        .replace('px)', '') || 0,
+    );
+    bottomSheetElement.style.transitionDuration = TRANSFORM_DURATION;
+
+    if (finalTransformValue < closingY) {
+      bottomSheetElement.style.transform = `translateY(0px)`;
+    } else {
+      closeBottomSheet();
+    }
+
+    metrics.current.isContentAreaTouched = false;
+    metrics.current.initTouchPosition = null;
+  };
+
+  const handleContentTouch = () => {
+    metrics.current.isContentAreaTouched = true;
+  };
+
+  const handleTouch = {
+    start: (e: TouchEvent) => handleStart(e.touches[0].clientY),
+    move: (e: TouchEvent) => handleMove(e.touches[0].clientY, e),
+    end: handleEnd,
+  };
+
+  const handleMouse = {
+    down: (e: MouseEvent) => handleStart(e.clientY),
+    move: (e: MouseEvent) => handleMove(e.clientY, e),
+    up: handleEnd,
+    leave: handleEnd,
+  };
+
+  return { bottomSheetRef, contentRef, openBottomSheet, closeBottomSheet };
+};
+
+export default useBottomSheet;


### PR DESCRIPTION
## ✏️ 작업 내용

- 바텀시트 틀을 구현했습니다.
- 바텀시트 드래그 기능을 위해 커스텀 훅을 구현했습니다.

## 📷 스크린샷

https://github.com/user-attachments/assets/66dc6f5d-b453-4c30-9a59-8602808cb945


## ✍️ 사용법
### useBottomSheet
`BottomSheet` 컴포넌트 내부에 원하는 컨텐츠를 넣고, `useBottomSheet`으로 기능을 연결합니다.
`contentRef`를 통해 드래그 기능을 끌 영역을 지정할 수 있습니다.

```tsx
  const { bottomSheetRef, contentRef, openBottomSheet, closeBottomSheet } =
    useBottomSheet();

  return (
    <div>
      <button onClick={() => openBottomSheet()}>열기</button>
      <BottomSheet ref={bottomSheetRef} title={'바텀시트 제목입니다'}>
        <div ref={contentRef} className='flex flex-col gap-12'>
          ...
        </div>
      </BottomSheet>
    </div>
  );
```

