### PR TITLE
feat: 포인트 관련 페이지들 기초 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from 'react-router-dom';
+import { Outlet, RouterProvider } from 'react-router-dom';
 import { createRouter } from 'routes';
 import Layout from 'components/common/Layout';
 import Provider from 'components/common/Provider';

--- a/src/components/common/PointCard.tsx
+++ b/src/components/common/PointCard.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  point: number;
+  title: string;
+  price: number;
+}
+
+const PointCard = ({ point, title, price }: Props) => {
+  return (
+    <li className='flex justify-between gap-12'>
+      <div className='h-40 w-80 bg-grey-4'>{point}p</div>
+      <div className='h-40 w-80 bg-grey-4'>{title}</div>
+      <div>{price}원</div>
+    </li>
+  );
+};
+
+export default PointCard;

--- a/src/pages/PointPage.tsx
+++ b/src/pages/PointPage.tsx
@@ -1,7 +1,12 @@
+import { useNavigate, useParams } from 'react-router-dom';
 import useBottomSheet from 'hooks/useBottomSheet';
+import PointCard from 'components/common/PointCard';
 import BottomSheet from 'components/common/bottom-sheet/BottomSheet';
 
 const PointPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
   const { bottomSheetRef, contentRef, openBottomSheet } = useBottomSheet();
 
   return (
@@ -23,11 +28,13 @@ const PointPage = () => {
             </ul>
           </div>
           <ul>
-            <PointItem point={10000} price={10000} />
-            <PointItem point={20000} price={20000} />
-            <PointItem point={30000} price={30000} />
+            <PointCard point={10000} price={10000} title='원데이' />
+            <PointCard point={20000} price={20000} title='5회권' />
+            <PointCard point={30000} price={30000} title='10회권' />
           </ul>
-          <button>결제하기</button>
+          <button onClick={() => navigate(`/${id}/point/purchase`)}>
+            결제하기
+          </button>
         </main>
       </div>
       <BottomSheet ref={bottomSheetRef} title={'결제규정'}>
@@ -51,20 +58,6 @@ const MyPointItem = ({ point, expiredAt }: MyPointItemProps) => {
     <li className='flex items-center justify-between'>
       <span>{point}p</span>
       <span>{expiredAt}</span>
-    </li>
-  );
-};
-
-interface PointItemProps {
-  point: number;
-  price: number;
-}
-
-const PointItem = ({ point, price }: PointItemProps) => {
-  return (
-    <li className='flex justify-between gap-12'>
-      <div className='h-40 w-80 bg-grey-4'>{point}p</div>
-      <div>{price}원</div>
     </li>
   );
 };

--- a/src/pages/PointPage.tsx
+++ b/src/pages/PointPage.tsx
@@ -1,29 +1,41 @@
+import useBottomSheet from 'hooks/useBottomSheet';
+import BottomSheet from 'components/common/bottom-sheet/BottomSheet';
+
 const PointPage = () => {
+  const { bottomSheetRef, contentRef, openBottomSheet } = useBottomSheet();
+
   return (
-    <div>
-      <header>지갑</header>
-      <main className='flex flex-col gap-20 p-20'>
-        <div>
-          <span>JUST JERK ACADEMY</span>
-          <button>결제규정</button>
-          <button>결제내역</button>
-        </div>
-        <div>
-          <span>권태현님</span>
+    <>
+      <div>
+        <header>지갑</header>
+        <main className='flex flex-col gap-20 p-20'>
+          <div>
+            <span>JUST JERK ACADEMY</span>
+            <button onClick={() => openBottomSheet()}>결제규정</button>
+            <button>결제내역</button>
+          </div>
+          <div>
+            <span>권태현님</span>
+            <ul>
+              <MyPointItem point={30000} expiredAt='24.12.03' />
+              <MyPointItem point={20000} expiredAt='24.12.03' />
+              <MyPointItem point={10000} expiredAt='24.12.03' />
+            </ul>
+          </div>
           <ul>
-            <MyPointItem point={30000} expiredAt='24.12.03' />
-            <MyPointItem point={20000} expiredAt='24.12.03' />
-            <MyPointItem point={10000} expiredAt='24.12.03' />
+            <PointItem point={10000} price={10000} />
+            <PointItem point={20000} price={20000} />
+            <PointItem point={30000} price={30000} />
           </ul>
+          <button>결제하기</button>
+        </main>
+      </div>
+      <BottomSheet ref={bottomSheetRef} title={'결제규정'}>
+        <div ref={contentRef} className='flex flex-col gap-12'>
+          결제 규정입니다
         </div>
-        <ul>
-          <PointItem point={10000} price={10000} />
-          <PointItem point={20000} price={20000} />
-          <PointItem point={30000} price={30000} />
-        </ul>
-        <button>결제하기</button>
-      </main>
-    </div>
+      </BottomSheet>
+    </>
   );
 };
 

--- a/src/pages/PointPage.tsx
+++ b/src/pages/PointPage.tsx
@@ -1,0 +1,58 @@
+const PointPage = () => {
+  return (
+    <div>
+      <header>지갑</header>
+      <main className='flex flex-col gap-20 p-20'>
+        <div>
+          <span>JUST JERK ACADEMY</span>
+          <button>결제규정</button>
+          <button>결제내역</button>
+        </div>
+        <div>
+          <span>권태현님</span>
+          <ul>
+            <MyPointItem point={30000} expiredAt='24.12.03' />
+            <MyPointItem point={20000} expiredAt='24.12.03' />
+            <MyPointItem point={10000} expiredAt='24.12.03' />
+          </ul>
+        </div>
+        <ul>
+          <PointItem point={10000} price={10000} />
+          <PointItem point={20000} price={20000} />
+          <PointItem point={30000} price={30000} />
+        </ul>
+        <button>결제하기</button>
+      </main>
+    </div>
+  );
+};
+
+export default PointPage;
+
+interface MyPointItemProps {
+  point: number;
+  expiredAt: string;
+}
+
+const MyPointItem = ({ point, expiredAt }: MyPointItemProps) => {
+  return (
+    <li className='flex items-center justify-between'>
+      <span>{point}p</span>
+      <span>{expiredAt}</span>
+    </li>
+  );
+};
+
+interface PointItemProps {
+  point: number;
+  price: number;
+}
+
+const PointItem = ({ point, price }: PointItemProps) => {
+  return (
+    <li className='flex justify-between gap-12'>
+      <div className='h-40 w-80 bg-grey-4'>{point}p</div>
+      <div>{price}원</div>
+    </li>
+  );
+};

--- a/src/pages/PointPage.tsx
+++ b/src/pages/PointPage.tsx
@@ -17,7 +17,9 @@ const PointPage = () => {
           <div>
             <span>JUST JERK ACADEMY</span>
             <button onClick={() => openBottomSheet()}>결제규정</button>
-            <button>결제내역</button>
+            <button onClick={() => navigate(`/${id}/point/purchase/history`)}>
+              결제내역
+            </button>
           </div>
           <div>
             <span>권태현님</span>

--- a/src/pages/PurchaseHistoryPage.tsx
+++ b/src/pages/PurchaseHistoryPage.tsx
@@ -1,0 +1,20 @@
+const PurchaseHistoryPage = () => {
+  return (
+    <div>
+      <header>결제내역</header>
+      <main>
+        <section>
+          <span>권태현님</span>
+        </section>
+        <section>
+          <h3>구매/사용이력</h3>
+          <ul>
+            <li>24/11/13 | 300,000p(10회권)</li>
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default PurchaseHistoryPage;

--- a/src/pages/PurchasePage.tsx
+++ b/src/pages/PurchasePage.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import useBottomSheet from 'hooks/useBottomSheet';
+import PointCard from 'components/common/PointCard';
+import BottomSheet from 'components/common/bottom-sheet/BottomSheet';
+
+const PurchasePage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const { bottomSheetRef, contentRef, openBottomSheet, closeBottomSheet } =
+    useBottomSheet();
+
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  return (
+    <>
+      {!isCompleted ? (
+        <div>
+          <header>결제하기</header>
+          <main className='flex flex-col gap-20 p-20'>
+            <section>
+              <h3>결제 상품</h3>
+              <PointCard point={30000} title='10회권' price={30000} />
+            </section>
+            <section>
+              <h3>결제자 정보</h3>
+              <p>이재용(010-8479-0507)</p>
+            </section>
+            <section>
+              <h3>입금 계좌</h3>
+              <p>(우리) 310-02203xx (김땡땡)</p>
+            </section>
+            <label>
+              <input type='checkbox' />
+              <span>계좌 이체를 완료했어요.</span>
+            </label>
+            <button onClick={openBottomSheet}>다음</button>
+          </main>
+        </div>
+      ) : (
+        <main>
+          <PointCard point={30000} title='10회권' price={30000} />
+          <p>구매 확정! 감사합니다.</p>
+
+          <button onClick={() => navigate(`/${id}/point`)}>내 지갑으로</button>
+          <button onClick={() => navigate(`/${id}`)}>메인 화면으로</button>
+        </main>
+      )}
+      <BottomSheet ref={bottomSheetRef}>
+        <div ref={contentRef} className='flex flex-col gap-12'>
+          규정 미준수로 인한 불이익이 발생할 수 있음을 확인했습니다.
+          <button
+            onClick={() => {
+              setIsCompleted(true);
+              closeBottomSheet();
+            }}
+          >
+            완료
+          </button>
+        </div>
+      </BottomSheet>
+    </>
+  );
+};
+
+export default PurchasePage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
+import PointPage from 'pages/PointPage';
 import Test from 'pages/Test';
 
 export const createRouter = () => {
@@ -6,6 +7,10 @@ export const createRouter = () => {
     {
       path: '/test',
       element: <Test />,
+    },
+    {
+      path: '/:id/point',
+      element: <PointPage />,
     },
   ]);
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,16 +1,26 @@
 import { createBrowserRouter } from 'react-router-dom';
 import PointPage from 'pages/PointPage';
+import PurchasePage from 'pages/PurchasePage';
 import Test from 'pages/Test';
 
 export const createRouter = () => {
   return createBrowserRouter([
     {
-      path: '/test',
-      element: <Test />,
-    },
-    {
-      path: '/:id/point',
-      element: <PointPage />,
+      path: '/',
+      children: [
+        {
+          path: 'test',
+          element: <Test />,
+        },
+        {
+          path: ':id/point',
+          element: <PointPage />,
+        },
+        {
+          path: ':id/point/purchase',
+          element: <PurchasePage />,
+        },
+      ],
     },
   ]);
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import PointPage from 'pages/PointPage';
+import PurchaseHistoryPage from 'pages/PurchaseHistoryPage';
 import PurchasePage from 'pages/PurchasePage';
 import Test from 'pages/Test';
 
@@ -19,6 +20,10 @@ export const createRouter = () => {
         {
           path: ':id/point/purchase',
           element: <PurchasePage />,
+        },
+        {
+          path: ':id/point/purchase/history',
+          element: <PurchaseHistoryPage />,
         },
       ],
     },


### PR DESCRIPTION
## ✏️ 작업 내용

포인트 구매, 포인트 결제, 결제 내역 페이지의 틀만 구현해두었습니다.

## 📷 스크린샷


https://github.com/user-attachments/assets/0ec3c4b3-5b72-4254-a6fa-20d33f94caab


## 🎸 기타

오늘 와이어프레임이 수정되면서 결제 내역 페이지가 다른 곳으로 이동된 것으로 보이는데, 추후에 위치가 확정되면 해당 부분에서 페이지를 사용하면 될 것 같습니다.
